### PR TITLE
Add error handling for blob failures

### DIFF
--- a/lib/scripts/dpapi.py
+++ b/lib/scripts/dpapi.py
@@ -130,7 +130,7 @@ class DPAPI:
 
             if not decrypted:
                 logger.debug(f"[-] Failed to decrypt blob for masterkey: {mkid}")
-            continue
+                continue
     
             decoded_string = decrypted.decode('utf-16le').split('\x00')
             domain, username, password = decoded_string[:3]

--- a/lib/scripts/dpapi.py
+++ b/lib/scripts/dpapi.py
@@ -122,10 +122,15 @@ class DPAPI:
                 logger.info("[!] Could not decrypt masterkey " + mkid)
                 continue  # skip this blob, try next
     
-            decrypted = blob.decrypt(key, entropy)
+            try:
+                decrypted = blob.decrypt(key, entropy)
+            except ValueError as e:
+                logger.debug(f"[-] Failed to decrypt blob for masterkey {mkid}: {e}")
+                continue
+
             if not decrypted:
                 logger.debug(f"[-] Failed to decrypt blob for masterkey: {mkid}")
-                continue  # skip, try next
+            continue
     
             decoded_string = decrypted.decode('utf-16le').split('\x00')
             domain, username, password = decoded_string[:3]


### PR DESCRIPTION
Found an issue when dumping credentials from the Management Server where a blob failing to decode would crash the tool. Updated the code to handle decode failures gracefully by skipping the failed blob and continuing to the next one.